### PR TITLE
docs: update memory paths in command templates

### DIFF
--- a/.roo/commands/init-orchestrator.md
+++ b/.roo/commands/init-orchestrator.md
@@ -40,21 +40,21 @@ Ask:
 4) Any non-negotiables (stakeholder promises, demo dates, contracts)?
 
 ## Produce (after interview)
-1) **Memory/Implementation_Plan.md** — include:
+1) **.roo-orchestrator/Memory/Implementation_Plan.md** — include:
    - Goals, Constraints
    - Deliverables (with acceptance criteria)
    - Work Breakdown by Milestone → Tasks (each task with guiding notes)
    - Ownership: which Roo mode (Code/Debug/Ask) is expected to execute
-2) **Memory/BACKLOG.md** — prioritized list of ≤45-minute tasks, with **Acceptance** checks.
-3) **Memory/ledger.md** — init summary (what we learned, decisions taken).
-4) **Memory/handoffs.md** — if unknowns remain, **HANDOFF to Ask** with top questions.
+2) **.roo-orchestrator/Memory/BACKLOG.md** — prioritized list of ≤45-minute tasks, with **Acceptance** checks.
+3) **.roo-orchestrator/Memory/ledger.md** — init summary (what we learned, decisions taken).
+4) **.roo-orchestrator/Memory/handoffs.md** — if unknowns remain, **HANDOFF to Ask** with top questions.
 5) If evidence is needed (tree, tests, configs), emit a **HANDOFF to Code** to run safe commands and paste outputs back.
 
 ## Acceptance (for Orchestrator to self-check)
 - [ ] Interview completed in ≤4 rounds
-- [ ] Memory/Implementation_Plan.md created/updated
-- [ ] Memory/BACKLOG.md created with ≤45-minute tasks
-- [ ] Memory files updated
+- [ ] .roo-orchestrator/Memory/Implementation_Plan.md created/updated
+- [ ] .roo-orchestrator/Memory/BACKLOG.md created with ≤45-minute tasks
+- [ ] .roo-orchestrator/Memory files updated
 - [ ] Handoff(s) created if unknowns block the next step
 
 ## Next Step

--- a/.roo/commands/memory-compact.md
+++ b/.roo/commands/memory-compact.md
@@ -1,6 +1,6 @@
-Summarize the older entries in Memory/ledger.md and Memory/handoffs.md into
-Memory/archives/<YYYY-MM>/ledger-<YYYY-MM>.md and handoffs-<YYYY-MM>.md.
+Summarize the older entries in .roo-orchestrator/Memory/ledger.md and .roo-orchestrator/Memory/handoffs.md into
+.roo-orchestrator/Memory/archives/<YYYY-MM>/ledger-<YYYY-MM>.md and .roo-orchestrator/Memory/archives/<YYYY-MM>/handoffs-<YYYY-MM>.md.
 
 Keep only the last ~200 lines in each rolling file.
 Write a "Highlights / Decisions / Open Questions" header at the top of each archive file,
-and add links/refs to any ADRs or commits. Update Memory/Implementation_Plan.md to reflect any milestone closures.
+and add links/refs to any ADRs or commits. Update .roo-orchestrator/Memory/Implementation_Plan.md to reflect any milestone closures.

--- a/.roo/commands/return-to-orchestrator.md
+++ b/.roo/commands/return-to-orchestrator.md
@@ -1,1 +1,1 @@
-Update Memory/handoffs.md, Memory/ledger.md, and Memory/BACKLOG.md with this RESULT, then switch to Orchestrator mode.
+Update .roo-orchestrator/Memory/handoffs.md, .roo-orchestrator/Memory/ledger.md, and .roo-orchestrator/Memory/BACKLOG.md with this RESULT, then switch to Orchestrator mode.

--- a/.roo/commands/rotate-milestone.md
+++ b/.roo/commands/rotate-milestone.md
@@ -1,4 +1,4 @@
-Move completed milestones from Memory/Implementation_Plan.md to Memory/archives/<YYYY-MM>/plan-<YYYY-MM>.md.
+Move completed milestones from .roo-orchestrator/Memory/Implementation_Plan.md to .roo-orchestrator/Memory/archives/<YYYY-MM>/plan-<YYYY-MM>.md.
 Leave only the current 1–2 milestones active. Ensure each archived milestone has:
 - Final acceptance notes
 - Links to RESULT evidence


### PR DESCRIPTION
## Summary
- point slash command templates at `.roo-orchestrator/Memory` directory
- keep command docs consistent with new project memory location

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run validate-handoff`


------
https://chatgpt.com/codex/tasks/task_e_68b9f6c12a2c83339dc48d98525eaed8